### PR TITLE
editorconfig を追加した

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
# 目的
エディタ毎に設定を変更されるとファイルのスタイルが統一できなくなってしまう。
そこでメジャーなエディタであればサポートされている .editorconfig を追加し、細かいエディタの挙動を統一できるようにする。

# 変更
- 全てのファイル
  - 改行文字を LF に
  - 最終行をエディタ上で改行
  - 行の最終文字がスペースならばこれを削除
  - 文字セットは UTF-8 に
- python ファイル
  - インデントのスタイルは4文字スペースに統一([pep8](https://www.python.org/dev/peps/pep-0008/#indentation) でも 4文字スペースにすることが要求されている)
- markdown ファイル
  - markdown はドキュメントのため、行の最終文字がスペースであっても意味がある場合があるため、行の最終文字のスペースは削除しないように
  - インデントのスタイルは 2 文字スペースが一般的と思われるので、それに統一