### PR TITLE
改行文字の実態があってなかったので修正した

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 root = true
 
 [*]
-end_of_line = lf
+end_of_line = crlf
 insert_final_newline = true
 trim_trailing_whitespace = true
 charset = utf-8


### PR DESCRIPTION
# 目的
editorconfig に指定する改行文字を変更

# 詳細
#2 では .editorconfig に `end_of_line = lf` を設定していたが、実際の Python コードは CR+LF になっていたため、 `.editorconfig` もそちらの実態に合わせた