### PR TITLE
必要のないファイルチェックを削除した

### DIFF
--- a/booth_order_list.py
+++ b/booth_order_list.py
@@ -20,11 +20,7 @@ def main():
 
     args = parser.parse_args()
 
-    filename = args.file
-    if not os.path.isfile(filename):
-        raise FileExistsError('File is not found.')
-
-    with open(filename, 'r', encoding='utf-8_sig') as f:
+    with open(args.file, 'r', encoding='utf-8_sig') as f:
         csv_data = csv.reader(f)
         data = [e for e in csv_data]
 


### PR DESCRIPTION
# 目的
二重チェックしてしまってる部分を削除する

# 原理
- `open` で `r` が指定されている場合はファイルが存在しなければ FileNotFoundError が raise されるため、事前に存在性チェックしている行を削除した。
- デフォルトでは `open` にあたえられるモードは `'r'` なので、 `open` に指定する必要はないのでモードは省略した
  - https://docs.python.org/ja/3/library/functions.html#open

## 余談...
スレッドを切ってないのであまり問題にはならないが、たとえばあるスレッド Ta がファイル A を削除し、もう1つ別のスレッド Tb がファイル A の存在性チェックを行ってから open するとすると、 Tb がファイルの存在チェックをした直後にスレッド Ta がファイル A を削除した場合、それに Tb は気付かずに open することとなって例外が発生することになる。
つまり、存在性チェックと open がアトミックな処理になってないので、結局ファイルの open には失敗しってしまうことになる。
これはわかりにくいバグのもとにもなるし、元々開けなければ例外が飛ぶため、ファイルが開けるかをそのままためして駄目ならば例外が飛んでくるというような設計にすると余計な存在性チェックもしなくてよくなる上に、コードの見通しも確保できる。

## 参考
[result.txt](https://github.com/hinananoha/booth-order-list/files/7594205/result.txt)