### PR TITLE
CSV の行数チェックを見直した

### DIFF
--- a/booth_order_list.py
+++ b/booth_order_list.py
@@ -28,9 +28,7 @@ def main():
         csv_data = csv.reader(f)
         data = [e for e in csv_data]
 
-    if not data:
-        raise ValueError('CSV file is empty or not csv file.')
-    elif not len(data[0]) == 15:
+    if len(data[0]) != 15:
         raise ValueError('This csv file is not booth order file.')
 
     date_range = []


### PR DESCRIPTION
# 目的
行数チェックのロジックを見直した

# 詳細
`not data` のチェックで CSV ファイルの中身が空なのかをチェックしているが、これはそもそも行数が 15 行に足りていないということの特殊な条件を満たす場合の言い換えにすぎず、結局中身が空であれば仮定している CSV ファイルの構造としては不十分であるというエラーメッセージだけでユーザーにはわかると思われる。
したがって、空判定チェックを削除した。