### PR TITLE
長さ判定ロジックを修正した

### DIFF
--- a/booth_order_list.py
+++ b/booth_order_list.py
@@ -26,7 +26,7 @@ def main():
 
     if not data:
         raise ValueError('CSV file is empty or not csv file.')
-    elif not len(data[0]) == 15:
+    elif len(data[0]) != 15:
         raise ValueError('This csv file is not booth order file.')
 
     date_range = []


### PR DESCRIPTION
# 目的
長さのチェックをよりわかりやすくする

# 詳細
`==` で判定してから `not` にかけるよりも同じ意味を持つ `!=` の方が文字数が少なくなる上に、否定の条件をより直感的に表現しているため、判定式を修正した