### PR TITLE
期間を指定する部分を改善した

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ optional arguments:
 以下、このスクリプトを使って色々なことをしたい、上級者向けの説明です。
 
 ## Requirement (Tested environment)
-- Python 3.x
+- Python 3.7 or greater than
   - tested env
     - ubuntu 18.04 (Python 3.6.9)
     - Windows 10 x64 (Python 3.9.2)

--- a/booth_order_list.py
+++ b/booth_order_list.py
@@ -1,8 +1,131 @@
+from __future__ import annotations
 import csv
 import os
 import argparse
 import datetime
-import re
+from typing import Optional
+import datetime
+import calendar
+import json
+
+
+class Period(object):
+    """
+    期間を表す。
+    期間の開始時間や終了時間はなくてかまわない。
+    なので、「2020/10/10 まで」のようなものもあらわすこともできるし、
+    「2020/10/10 以降」のようなものもあらわせる。
+    また、期限なしということも表現できる。
+    """
+
+    def __init__(
+        self,
+        begin: Optional[datetime.datetime] = None,
+        end: Optional[datetime.datetime] = None
+    ):
+        """
+        begin: 期限の開始時間。 None は開始日がないことを表す
+        end: 期限の終了日。 None は終了日がないことを表す
+        """
+        if not (isinstance(begin, datetime.datetime) or begin is None):
+            raise ValueError(
+                f"begin type is not datetime.datetime: {type(begin).__name__}")
+        if not (isinstance(end, datetime.datetime) or end is None):
+            raise ValueError(
+                f"end type is not datetime.datetime: {type(end).__name__}")
+        if all(map(lambda i: isinstance(i, datetime.datetime), [begin, end])) and begin > end:
+            raise ValueError(f"begin > end: begin = {begin}, end = {end}")
+
+        self.__begin = begin
+        self.__end = end
+
+    @property
+    def begin(self) -> Optional[datetime.datetime]:
+        """
+        期間の開始時間
+        """
+        return self.__begin
+
+    @property
+    def end(self) -> Optional[datetime.datetime]:
+        """
+        期間の終了時間
+        """
+        return self.__end
+
+    @classmethod
+    def from_str(cls, begin: Optional[str] = None, end: Optional[str] = None) -> Period:
+        """
+        文字列から組み立てる。それぞれの文字列は最終的に
+        datetime.datetime.strptime によって "%Y-%m-%d"
+        のようにパースされる
+
+        begin: 期限の開始時間。 None は開始日がないことを表す
+        end: 期限の終了日。 None は終了日がないことを表す
+        """
+        if not (isinstance(begin, str) or begin is None):
+            raise ValueError(f"begin type is not str: {type(begin).__name__}")
+        if not (isinstance(end, str) or end is None):
+            raise ValueError(f"end type is not str: {type(end).__name__}")
+
+        def to_datetime(s: Optional[str]) -> Optional[datetime.datetime]:
+            return None if s is None else datetime.datetime.strptime(s, "%Y-%m-%d")
+
+        return cls(to_datetime(begin), to_datetime(end))
+
+    def __str__(self):
+        return f"{self.begin} ~ {self.end}"
+
+    def __contains__(self, date: datetime.datetime) -> bool:
+        if not isinstance(date, datetime.datetime):
+            raise ValueError(
+                f"date type is not datetime.datetime: {type(date).__name__}")
+        elif self.begin is None and self.end is None:
+            # 開始時間も終了時間も指定されてないならどんな日程が渡されても期間内
+            return True
+        elif self.begin is None:
+            # 開始時間が指定されてないなら終了時間だけ見ればよい
+            return date <= self.end
+        elif self.end is None:
+            # 終了時間が指定されてないなら開始時間だけ見ればよい
+            return self.begin <= date
+        return self.begin <= date <= self.end
+
+
+def parse_period(period: str) -> Period:
+    """
+    渡された文字列を period にパースする。
+
+    渡される文字列の形式としては以下の形を仮定する。
+    - { "type": "current-month" }: 今月が期間として指定された
+    - { "type": "period", "begin": "%Y-%m-%d", "end": "%Y-%m-%d" }: ある一定の期間が指定された
+        + begin や end といったプロパティはオプショナル
+    """
+    if not isinstance(period, str):
+        ValueError(f"period type is not str: {type(period).__name__}")
+
+    typ = json.loads(period)
+    if "type" not in typ:
+        raise KeyError("period format must be {\"type\": type, ...}")
+
+    if typ["type"] == "current-month":
+        today = datetime.datetime.today()
+        _, last_day = calendar.monthrange(today.year, today.month)
+        begin = datetime.datetime.combine(
+            datetime.datetime(today.year, today.month, 1),
+            datetime.time.min
+        )
+        end = datetime.datetime.combine(
+            datetime.datetime(today.year, today.month, last_day),
+            datetime.time.max,
+        )
+        return Period(begin, end)
+    elif typ["type"] == "period":
+        begin = typ["begin"] if "begin" in typ else None
+        end = typ["end"] if "end" in typ else None
+        return Period.from_str(begin, end)
+
+    raise KeyError("unknown period type: {}".format(period))
 
 
 def main():
@@ -13,10 +136,8 @@ def main():
         '-o', '--output', help='出力するCSVファイルのファイル名（必須）', required=True)
     parser.add_argument('-u', '--unshipped',
                         action='store_true', help='未発送の注文のリストを出力')
-    parser.add_argument('-c', '--current-month',
-                        action='store_true', help='今月の注文のリストを出力')
-    parser.add_argument('-r', '--range', nargs=2,
-                        help='指定した期間の注文リストを出力(YYYY-MM-DD YYYY-MM-DDで指定)')
+    parser.add_argument('-r', '--range', type=parse_period, action='store',
+                        help='対象期間を指定する。ここで指定した対象期間内の注文リストが出力される')
 
     args = parser.parse_args()
 
@@ -29,22 +150,7 @@ def main():
     elif not len(data[0]) == 15:
         raise ValueError('This csv file is not booth order file.')
 
-    date_range = []
-    if args.range:
-        for date_str in args.range:
-            if not re.fullmatch(r'[0-9]{4}-[0-9]{2}-[0-9]{2}', date_str):
-                raise ValueError('-r/--range option input is invalid.')
-            else:
-                date_range.append(datetime.datetime.strptime(date_str, '%Y-%m-%d'))
-
-    if args.current_month:
-        dt_now = datetime.datetime.now()
-        start_date = datetime.datetime(dt_now.year, dt_now.month, 1)
-        if dt_now.month == 12:
-            end_date = datetime.datetime(dt_now.year+1, 1, 1)
-        else:
-            end_date = datetime.datetime(dt_now.year, dt_now.month+1, 1)
-        date_range = [start_date, end_date]
+    period: Optional[Period] = args.range
 
     order_data = data[1:]
     create_data = []
@@ -60,8 +166,10 @@ def main():
         else:
             if order[3] == 'キャンセル':
                 continue
-        if date_range:
-            if datetime.datetime.strptime(order[4], '%Y-%m-%d  %H:%M:%S') < date_range[0] or datetime.datetime.strptime(order[4], '%Y-%m-%d  %H:%M:%S') >= date_range[1]:
+        if period is not None:
+            order_time = datetime.datetime.strptime(
+                order[4], '%Y-%m-%d  %H:%M:%S')
+            if order_time not in period:
                 continue
         order_infos = {}
         for order_info in order[14].split('\n'):
@@ -91,12 +199,10 @@ def main():
             'order': order_infos
         })
 
-
     header = ['注文番号', '注文日時', '支払い状況']
     for book_name in books.values():
         header.append(book_name)
     create_data.append(header)
-
 
     for order_book in order_books:
         data = [order_book['id'], order_book['date'], order_book['paid']]


### PR DESCRIPTION
# 目的
期間指定に `-c` と `-r` という2つのオプションが存在してるのを統一したい

# 詳細
統一するにあたって、 `-c` と `-r` を同一に扱えるフォーマットが必要となる。
そこで、 `-r` に JSON を指定できるようにして、これらを切り替えられるようにした。
現在は今月を意味する `{"type": "current-month" }` とある期間を表す `{"type": "period", "begin": "YYYY-mm-dd", "end": "YYYY-mm-dd"}` の2つのフォーマットを提供している。
つまり、 `type` プロパティに指定した種類によって JSON の内容を切り替えることで統一的にかつ柔軟に期間指定ができるようになった。

> `period` タイプの `begin` や `end` の指定はオプショナルとしてある。
> これによって「2020/12/10 以降」を抽出したり、「2020/10/01」までのデータを抽出できるようになった。

# 注意事項
これを含んだものをリリースする際は、後方互換性がなくなっているので v2.0.0 にバンプさせる必要がある