### PR TITLE
editorconfig 自身の改行を LF に統一した

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,7 @@ indent_size = 4
 trim_trailing_whitespace = false
 indent_style = space
 indent_size = 2
+
+[.editorconfig]
+end_of_line = lf
+


### PR DESCRIPTION
# 目的
editorconfig の改行文字を LF に統一する